### PR TITLE
Be able to add a file in draft to an article

### DIFF
--- a/djangocms_versioning_filer/monkeypatch/admin/__init__.py
+++ b/djangocms_versioning_filer/monkeypatch/admin/__init__.py
@@ -1,3 +1,4 @@
+from .admin_fields import *  # noqa
 from .clipboardadmin import *  # noqa
 from .fileadmin import *  # noqa
 from .folderadmin import *  # noqa

--- a/djangocms_versioning_filer/monkeypatch/admin/admin_fields.py
+++ b/djangocms_versioning_filer/monkeypatch/admin/admin_fields.py
@@ -1,0 +1,115 @@
+import logging
+
+from django.contrib.admin.widgets import ForeignKeyRawIdWidget
+from django.db.models import ForeignKey
+from django.template.loader import render_to_string
+from django.urls import reverse
+from django.utils.http import urlencode
+from django.utils.safestring import mark_safe
+
+import filer
+from filer import settings as filer_settings
+from filer.fields.file import AdminFileFormField
+from filer.models.filemodels import File
+
+from djangocms_versioning.helpers import remove_published_where
+
+
+logger = logging.getLogger(__name__)
+
+
+def render(self, name, value, attrs=None, renderer=None):
+    obj = self.obj_for_value(value)
+    css_id = attrs.get('id', 'id_image_x')
+    related_url = None
+    if value:
+        try:
+            # We need to get the original manager to be able to access drafts.
+            file_obj = File._original_manager.get(pk=value)
+            related_url = file_obj.logical_folder.get_admin_directory_listing_url_path()
+        except Exception as e:
+            # catch exception and manage it. We can re-raise it for debugging
+            # purposes and/or just logging it, provided user configured
+            # proper logging configuration
+            if filer_settings.FILER_ENABLE_LOGGING:
+                logger.error('Error while rendering file widget: %s', e)
+            if filer_settings.FILER_DEBUG:
+                raise
+    if not related_url:
+        related_url = reverse('admin:filer-directory_listing-last')
+    params = self.url_parameters()
+    params['_pick'] = 'file'
+    if params:
+        lookup_url = '?' + urlencode(sorted(params.items()))
+    else:
+        lookup_url = ''
+    if 'class' not in attrs:
+        # The JavaScript looks for this hook.
+        attrs['class'] = 'vForeignKeyRawIdAdminField'
+    # rendering the super for ForeignKeyRawIdWidget on purpose here because
+    # we only need the input and none of the other stuff that
+    # ForeignKeyRawIdWidget adds
+    hidden_input = super(ForeignKeyRawIdWidget, self).render(name, value, attrs)
+    context = {
+        'hidden_input': hidden_input,
+        'lookup_url': '%s%s' % (related_url, lookup_url),
+        'object': obj,
+        'lookup_name': name,
+        'id': css_id,
+        'admin_icon_delete': ('admin/img/icon-deletelink.svg'),
+    }
+    html = render_to_string('admin/filer/widgets/admin_file.html', context)
+    return mark_safe(html)
+
+
+def obj_for_value(self, value):
+    if value:
+        try:
+            key = self.rel.get_related_field().name
+            # we need the original manager to access draft
+            obj = self.rel.model._original_manager.get(**{key: value})
+        except Exception:
+            obj = None
+    else:
+        obj = None
+    return obj
+
+
+init = AdminFileFormField.__init__
+
+
+def __init__(self, rel, queryset, to_field_name, *args, **kwargs):
+    queryset = remove_published_where(queryset)
+    init(self, rel, queryset, to_field_name, *args, **kwargs)
+
+
+def validate(self, value, model_instance):
+    from django.core import exceptions
+    from django.db import router
+    if self.remote_field.parent_link:
+        return
+    super(ForeignKey, self).validate(value, model_instance)
+    if value is None:
+        return
+
+    using = router.db_for_read(self.remote_field.model, instance=model_instance)
+    # we need to use the original manager to access drafts
+    qs = self.remote_field.model._original_manager.using(using).filter(
+        **{self.remote_field.field_name: value}
+    )
+    qs = qs.complex_filter(self.get_limit_choices_to())
+    if not qs.exists():
+        raise exceptions.ValidationError(
+            self.error_messages['invalid'],
+            code='invalid',
+            params={
+                'model': self.remote_field.model._meta.verbose_name, 'pk': value,
+                'field': self.remote_field.field_name, 'value': value,
+            },  # 'pk' is included for backwards compatibility
+        )
+
+
+filer.fields.file.AdminFileWidget.render = render
+filer.fields.file.AdminFileWidget.obj_for_value = obj_for_value
+filer.fields.file.AdminFileFormField.__init__ = __init__
+filer.fields.file.FilerFileField.validate = validate

--- a/djangocms_versioning_filer/monkeypatch/admin/admin_fields.py
+++ b/djangocms_versioning_filer/monkeypatch/admin/admin_fields.py
@@ -1,3 +1,25 @@
+"""
+Regarding the monkeypatching that happens in this file. There is a fair amount
+of code being pulled in from django-filer which is unrelated to the actual
+monkeypatching that needs to happen.
+
+The following is what has been changed.
+
+file_obj = File._original_manager.get(pk=value)
+obj = self.rel.model._original_manager.get(**{key: value})
+queryset = remove_published_where(queryset)
+qs = self.remote_field.model._original_manager.using(using).filter(
+    **{self.remote_field.field_name: value}
+)
+
+The code that is patched is from the following commit
+https://github.com/divio/django-filer/tree/655ead261d124cf5b943abdcf30c7921aa20374f
+
+To avoid pulling in so much code it would have been better to write
+small utility methods that gets the object for filer that then can be patched
+by versioning-filer.
+"""
+
 import logging
 
 from django.contrib.admin.widgets import ForeignKeyRawIdWidget
@@ -8,11 +30,10 @@ from django.utils.http import urlencode
 from django.utils.safestring import mark_safe
 
 import filer
+from djangocms_versioning.helpers import remove_published_where
 from filer import settings as filer_settings
 from filer.fields.file import AdminFileFormField
 from filer.models.filemodels import File
-
-from djangocms_versioning.helpers import remove_published_where
 
 
 logger = logging.getLogger(__name__)

--- a/djangocms_versioning_filer/monkeypatch/admin/fileadmin.py
+++ b/djangocms_versioning_filer/monkeypatch/admin/fileadmin.py
@@ -39,10 +39,8 @@ def clean(func):
         if file_name and check_file_label_exists_in_folder(
             file_name, self.instance.folder, exclude_file_pks=[self.instance.pk]
         ):
-            self.add_error(
-                'name',
-                _('File with name "{}" already exists in "{}" folder').format(file_name, folder_name)
-            )
+            msg = _('File with name "{}" already exists in "{}" folder').format(file_name, folder_name)
+            self.add_error('name', msg)
         return cleaned_data
     return inner
 filer.admin.fileadmin.FileAdminChangeFrom.clean = clean(  # noqa: E305

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     description=djangocms_versioning_filer.__doc__,
     dependency_links=[
         "http://github.com/divio/django-cms/tarball/release/4.0.x#egg=django-cms-4.0.0",
-        "http://github.com/divio/djangocms-versioning/tarball/master#egg=djangocms-versioning-0.0.23",
+        "http://github.com/divio/djangocms-versioning/tarball/master#egg=djangocms-versioning-0.0.24",
     ],
     long_description=open('README.rst').read(),
     platforms=['OS Independent'],

--- a/tests/test_file_plugin.py
+++ b/tests/test_file_plugin.py
@@ -1,7 +1,9 @@
 from cms.api import add_plugin
-from cms.models import CMSPlugin
-from cms.toolbar.utils import get_object_preview_url
+from cms.models import CMSPlugin, PageContent
+from cms.toolbar.utils import get_object_edit_url, get_object_preview_url
+from cms.views import details
 
+from djangocms_versioning.constants import DRAFT
 from filer.models import Folder
 
 from djangocms_versioning_filer.models import FileGrouper
@@ -15,21 +17,112 @@ class FilerFilePluginTestCase(BaseFilerVersioningTestCase):
         super().setUp()
         self.client.force_login(self.superuser)
 
-    def test_add_plugin(self):
+        self.draft_file_grouper = FileGrouper.objects.create()
+        self.draft_file = self.create_file_obj(
+            original_filename='test_draft.pdf',
+            folder=self.folder,
+            grouper=self.draft_file_grouper,
+            publish=False,
+        )
+
+    def add_plugin(self, grouper_pk):
         uri = self.get_add_plugin_uri(
             placeholder=self.placeholder,
             plugin_type='FilePlugin',
             language=self.language,
         )
 
-        data = {'file_grouper': self.file_grouper.pk, 'template': 'default'}
+        data = {'file_grouper': grouper_pk, 'template': 'default'}
         response = self.client.post(uri, data)
+        return response
+
+    def detail_response(self, page):
+        """Renders the article page, it's in draft at first so we also publish it"""
+        pagecontent = PageContent._original_manager.get(page=self.page.pk)
+        content_version = pagecontent.versions.all()[0]
+        content_version.publish(self.superuser)
+
+        url = page.get_absolute_url()
+        request = self.get_request(url)
+        response = details(request, page.get_path('en'))
+        return response
+
+    def test_render_detail_with_published_file(self):
+        """Rendering the article page should show the file"""
+        self.add_plugin(self.file_grouper.pk)
+
+        response = self.detail_response(self.page)
+        self.assertContains(response, self.file.url)
+
+    def test_render_detail_with_draft_file_only(self):
+        """Rendering article page with draft file does not render the draft file"""
+        self.add_plugin(self.draft_file_grouper)
+
+        response = self.detail_response(self.page)
+        self.assertNotContains(response, self.draft_file.url)
+        self.assertNotContains(response, 'href="/media')
+
+    def test_render_detail_with_published_file_and_draft(self):
+        """
+        Rendering article page with a file that has both a draft and published
+        file will render the published file.
+        """
+        self.assertEqual(self.file.versions.all().count(), 1)
+        version = self.file.versions.all().first()
+        v2 = version.copy(self.superuser)
+
+        self.assertEqual(v2.state, DRAFT)
+        self.assertEqual(v2.grouper.pk, self.file.grouper.pk)
+
+        self.add_plugin(self.file_grouper.pk)
+
+        response = self.detail_response(self.page)
+        self.assertContains(response, self.file.url)
+
+        # clean-up
+        v2.delete()
+
+    def test_edit_endpoint_with_published_file(self):
+        """Edit endpoint contains published file"""
+        self.add_plugin(self.file_grouper.pk)
+
+        response = self.client.get(get_object_edit_url(self.placeholder.source))
+        self.assertContains(response, self.file.url)
+
+    def test_edit_endpoint_with_draft_file(self):
+        """Edit endpoint contains draft file"""
+        self.add_plugin(self.draft_file_grouper.pk)
+
+        response = self.client.get(get_object_edit_url(self.placeholder.source))
+        self.assertContains(response, self.draft_file.url)
+
+    def test_edit_endpoint_with_published_file_and_draft(self):
+        """Edit endpoint contains draft file when there is a published
+        and a draft version."""
+        self.assertEqual(self.file.versions.all().count(), 1)
+        version = self.file.versions.all().first()
+        v2 = version.copy(self.superuser)
+
+        self.assertEqual(v2.state, DRAFT)
+        self.assertEqual(v2.grouper.pk, self.file.grouper.pk)
+
+        self.add_plugin(self.file_grouper.pk)
+
+        response = self.client.get(get_object_edit_url(self.placeholder.source))
+        self.assertContains(response, v2.content.url)
+
+        # clean-up
+        v2.delete()
+
+    def test_add_plugin(self):
+        response = self.add_plugin(self.file_grouper.pk)
         self.assertEquals(response.status_code, 200)
 
         plugin = CMSPlugin.objects.latest('pk')
         self.assertEquals(plugin.get_bound_plugin().file_grouper.file.url, self.file.url)
 
     def test_plugin_rendering(self):
+        """Test plugin rendering for published file"""
         add_plugin(
             self.placeholder,
             'FilePlugin',
@@ -41,6 +134,7 @@ class FilerFilePluginTestCase(BaseFilerVersioningTestCase):
         response = self.client.get(
             get_object_preview_url(self.placeholder.source, self.language)
         )
+
         self.assertContains(response, self.file.url)
 
         draft_file = self.create_file_obj(


### PR DESCRIPTION
Regarding the monkeypatching that happens in this file. There is a fair amount
of code being pulled in from django-filer which is unrelated to the actual
monkeypatching that needs to happen.

The following is what has been changed.
```
file_obj = File._original_manager.get(pk=value)
obj = self.rel.model._original_manager.get(**{key: value})
queryset = remove_published_where(queryset)
qs = self.remote_field.model._original_manager.using(using).filter(
    **{self.remote_field.field_name: value}
)
````
The code that is patched is from the following commit
https://github.com/divio/django-filer/tree/655ead261d124cf5b943abdcf30c7921aa20374f

To avoid pulling in so much code it would have been better to write
small utility methods that gets the object for filer that then can be patched
by versioning-filer.

Depends on https://github.com/divio/djangocms-versioning/pull/207