### PR TITLE
Url is different for published and unpublished files depending on edit mode

### DIFF
--- a/djangocms_versioning_filer/monkeypatch/models.py
+++ b/djangocms_versioning_filer/monkeypatch/models.py
@@ -17,6 +17,19 @@ def unsorted_images_files(self):
     return get_files_distinct_grouper_queryset().filter(folder__isnull=True)
 filer.models.virtualitems.UnsortedImages.files = property(unsorted_images_files)   # noqa: E305
 
+
+def url(self):
+    """
+    to make the model behave like a file field
+    """
+    try:
+        r = self.grouper.file.file.url
+    except Exception:  # noqa
+        r = ''
+    return r
+
+
+filer.models.File.url = property(url)
 filer.models.File._meta.base_manager_name = '_original_manager'
 
 

--- a/djangocms_versioning_filer/monkeypatch/views.py
+++ b/djangocms_versioning_filer/monkeypatch/views.py
@@ -12,5 +12,6 @@ def canonical(request, uploaded_at, file_id):
 
     if (not filer_file.file or int(uploaded_at) != filer_file.canonical_time):
         raise Http404('No %s matches the given query.' % File._meta.object_name)
-    return redirect(filer_file.url)
+    url = filer_file.url or filer_file.file.url
+    return redirect(url)
 filer_views.canonical = canonical  # noqa: E305

--- a/djangocms_versioning_filer/plugins/file/cms_plugins.py
+++ b/djangocms_versioning_filer/plugins/file/cms_plugins.py
@@ -2,7 +2,10 @@ from django.utils.translation import ugettext_lazy as _
 
 from cms.plugin_pool import plugin_pool
 
-from djangocms_file.cms_plugins import FilePlugin as BaseFilePlugin
+from djangocms_file.cms_plugins import (
+    FilePlugin as BaseFilePlugin,
+    FolderPlugin as BaseFolderPlugin,
+)
 
 from .models import VersionedFile
 
@@ -34,3 +37,12 @@ class FilePlugin(BaseFilePlugin):
 
 plugin_pool.unregister_plugin(BaseFilePlugin)
 plugin_pool.register_plugin(FilePlugin)
+
+
+class FolderPlugin(BaseFolderPlugin):
+    def get_render_template(self, context, instance, placeholder):
+        return 'djangocms_versioning_filer/plugins/{}/folder.html'.format(instance.template)
+
+
+plugin_pool.unregister_plugin(BaseFolderPlugin)
+plugin_pool.register_plugin(FolderPlugin)

--- a/djangocms_versioning_filer/templates/admin/filer/folder/directory_table.html
+++ b/djangocms_versioning_filer/templates/admin/filer/folder/directory_table.html
@@ -1,4 +1,4 @@
-{% load i18n l10n admin_list filer_tags filer_admin_tags staticfiles %}
+{% load i18n l10n admin_list filer_tags filer_admin_tags staticfiles versioning_filer %}
 <div class="drag-hover-border"></div>
 <section class="navigator{% if is_popup %} navigator-popup{% endif %}">
     <table class="js-filer-dropzone js-filer-dropzone-base navigator-table" id="result_list" data-url="{% if folder.id %}{% url 'admin:filer-ajax_upload' folder_id=folder.id %}{% else %}{% url 'admin:filer-ajax_upload' %}{% endif %}" data-folder-name="{% if folder.is_root %}{% trans 'Unsorted Uploads' %}{% else %}{{ folder.name }}{% endif %}" data-max-uploader-connections="{{ uploader_connections }}" data-max-file-size="20">
@@ -152,7 +152,7 @@
                             <td class="column-action">
                                 <a href="{{ file.canonical_url }}"
                                     title="{% blocktrans with file.label as item_label %}Canonical url '{{ item_label }}'{% endblocktrans %}" class="action-button" target="_blank"><span class="fa fa-link"></span></a>
-                                <a href="{{ file.url }}" target="_blank"
+                                <a href="{% get_url file %}" target="_blank"
                                     title="{% blocktrans with file.label as item_label %}Download '{{ item_label }}'{% endblocktrans %}" class="action-button"><span class="fa fa-download"></span></a>
                                 <a href="{{ file.grouper.get_absolute_url }}"
                                     title="{% blocktrans with file.label as item_label %}Manage '{{ item_label }}' versions{% endblocktrans %}" class="action-button"><span class="fa fa-pencil"></span></a>

--- a/djangocms_versioning_filer/templates/djangocms_versioning_filer/plugins/default/audio_file.html
+++ b/djangocms_versioning_filer/templates/djangocms_versioning_filer/plugins/default/audio_file.html
@@ -1,10 +1,10 @@
-{% load i18n cms_tags %}
+{% load i18n cms_tags versioning_filer %}
 
 {% with instance.audio_file.extension as ext %}
     <audio controls
         {% if instance.text_title %} title="{{ instance.text_title }}"{% endif %}
         {% if instance.attributes %} {{ instance.attributes_str }}{% endif %}>
-        <source src="{{ instance.audio_file.url }}" type="audio/{% if ext == "mp3" %}mpeg{% else %}{{ ext }}{% endif %}">
+        <source src="{% get_url instance.audio_file %}" type="audio/{% if ext == "mp3" %}mpeg{% else %}{{ ext }}{% endif %}">
         {{ instance.text_description }}
         {% for plugin in instance.child_plugin_instances %}
             {% render_plugin plugin %}

--- a/djangocms_versioning_filer/templates/djangocms_versioning_filer/plugins/default/audio_track.html
+++ b/djangocms_versioning_filer/templates/djangocms_versioning_filer/plugins/default/audio_track.html
@@ -1,4 +1,6 @@
-<track kind="{{ instance.kind }}" src="{{ instance.src.url }}"
+{% load versioning_filer %}
+
+<track kind="{{ instance.kind }}" src="{% get_url instance.src %}"
     {% if instance.srclang %} srclang="{{ instance.srclang }}"{% endif %}
     {% if instance.label %} label="{{ instance.label }}"{% endif %}
     {% if instance.attributes %} {{ instance.attributes_str }}{% endif %}

--- a/djangocms_versioning_filer/templates/djangocms_versioning_filer/plugins/default/file.html
+++ b/djangocms_versioning_filer/templates/djangocms_versioning_filer/plugins/default/file.html
@@ -1,4 +1,6 @@
-<a href="{{ instance.file_src.url }}"
+{% load versioning_filer %}
+
+<a href="{% get_url instance.file_src %}"
     {% if instance.link_target %} target="{{ instance.link_target }}"{% endif %}
     {% if instance.link_title %} title="{{ instance.link_title }}"{% endif %}
     {{ instance.attributes_str }}>

--- a/djangocms_versioning_filer/templates/djangocms_versioning_filer/plugins/default/folder.html
+++ b/djangocms_versioning_filer/templates/djangocms_versioning_filer/plugins/default/folder.html
@@ -1,0 +1,27 @@
+{% load i18n versioning_filer %}
+
+
+{% for file in folder_files %}
+    <a href="{% get_url file %}"
+        {% if instance.link_target %} target="{{ instance.link_target }}"{% endif %}
+        {{ instance.attributes_str }}>
+        {{ file }}
+        {% if instance.show_file_size %}
+            <span>{{ file.size|filesizeformat }}</span>
+        {% endif %}
+    </a>
+    {% if not forloop.last %}<br>{% endif %}
+{% empty %}
+    <p>{% trans "No files were found in the specified folder." %}</p>
+{% endfor %}
+
+{% comment %}
+    # https://github.com/divio/django-filer/blob/master/filer/models/filemodels.py
+    {{ instance.folder_src }}
+    {{ instance.get_files }} or {{ folder_files }}
+    # Available variables:
+    {{ instance.template }}
+    {{ instance.link_target }}
+    {{ instance.show_file_size }}
+    {{ instance.attributes_str }}
+{% endcomment %}

--- a/djangocms_versioning_filer/templates/djangocms_versioning_filer/plugins/default/video_player.html
+++ b/djangocms_versioning_filer/templates/djangocms_versioning_filer/plugins/default/video_player.html
@@ -1,4 +1,4 @@
-{% load i18n cms_tags %}
+{% load i18n cms_tags versioning_filer %}
 
 {% if instance.embed_link %}
     {# show iframe if embed_link is provided #}
@@ -11,7 +11,7 @@
 {% else %}
     {# render <source> or <track> plugins #}
     <video controls {{ instance.attributes_str }}
-        {% if instance.poster %} poster="{{ instance.poster.url }}"{% endif %}>
+        {% if instance.poster %} poster="{% get_url instance.poster %}"{% endif %}>
         {% for plugin in instance.child_plugin_instances %}
             {% render_plugin plugin %}
         {% endfor %}

--- a/djangocms_versioning_filer/templates/djangocms_versioning_filer/plugins/default/video_source.html
+++ b/djangocms_versioning_filer/templates/djangocms_versioning_filer/plugins/default/video_source.html
@@ -1,8 +1,8 @@
-{% load i18n cms_tags %}
+{% load i18n cms_tags versioning_filer %}
 
 {% if not disabled %}
     {% with instance.source_file.extension as ext %}
-        <source src="{{ instance.source_file.url }}" type="video/{{ ext }}" {{ instance.attributes_str }}>
+        <source src="{% get_url instance.source_file %}" type="video/{{ ext }}" {{ instance.attributes_str }}>
     {% endwith %}
 {% endif %}
 

--- a/djangocms_versioning_filer/templates/djangocms_versioning_filer/plugins/default/video_track.html
+++ b/djangocms_versioning_filer/templates/djangocms_versioning_filer/plugins/default/video_track.html
@@ -1,5 +1,7 @@
+{% load versioning_filer %}
+
 {% if not disabled %}
-    <track kind="{{ instance.kind }}" src="{{ instance.src.url }}"
+    <track kind="{{ instance.kind }}" src="{% get_url instance.src %}"
         {% if instance.srclang %} srclang="{{ instance.srclang }}"{% endif %}
         {% if instance.label %} label="{{ instance.label }}"{% endif %}
         {% if instance.attributes %} {{ instance.attributes_str }}{% endif %}

--- a/djangocms_versioning_filer/templatetags/versioning_filer.py
+++ b/djangocms_versioning_filer/templatetags/versioning_filer.py
@@ -1,0 +1,15 @@
+from django import template
+
+
+register = template.Library()
+
+
+@register.simple_tag(takes_context=True)
+def get_url(context, file):
+    toolbar = context.get('cms_toolbar')
+    current_url = context.get('current_url', '')
+
+    if (not toolbar or not toolbar.edit_mode_active) and 'admin' not in current_url:
+        return file.url
+
+    return file.file.url

--- a/tests/base.py
+++ b/tests/base.py
@@ -19,6 +19,18 @@ from djangocms_versioning_filer.models import FileGrouper
 from djangocms_versioning_filer.test_utils.helpers import create_image
 
 
+class MockToolbar:
+
+    @property
+    def edit_mode_active(self):
+        return True
+
+
+CONTEXT = {
+    'cms_toolbar': MockToolbar()
+}
+
+
 class BaseFilerVersioningTestCase(CMSTestCase):
 
     def setUp(self):

--- a/tests/test_file_plugin.py
+++ b/tests/test_file_plugin.py
@@ -1,5 +1,3 @@
-from unittest import skip
-
 from cms.api import add_plugin
 from cms.models import CMSPlugin, PageContent
 from cms.toolbar.utils import get_object_edit_url, get_object_preview_url
@@ -114,6 +112,7 @@ class FilerFilePluginTestCase(BaseFilerVersioningTestCase):
 
         v2_draft_url = get_url(CONTEXT, v2.content)
         response = self.client.get(get_object_edit_url(self.placeholder.source))
+
         self.assertContains(response, v2_draft_url)
 
         # clean-up
@@ -189,7 +188,6 @@ class FilerFilePluginTestCase(BaseFilerVersioningTestCase):
 
 class FilerFolderPluginTestCase(BaseFilerVersioningTestCase):
 
-    @skip('broken. For some reason it picks up the original djangocms_file template')
     def test_plugin_rendering(self):
         """
         Preview url does not contain url

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -18,8 +18,9 @@ from djangocms_versioning.models import Version
 from filer.models import File, Folder
 
 from djangocms_versioning_filer.models import FileGrouper
+from djangocms_versioning_filer.templatetags.versioning_filer import get_url
 
-from .base import BaseFilerVersioningTestCase
+from .base import CONTEXT, BaseFilerVersioningTestCase
 
 
 class FilerViewTests(BaseFilerVersioningTestCase):
@@ -245,9 +246,10 @@ class FilerViewTests(BaseFilerVersioningTestCase):
             grouper=FileGrouper.objects.create(),
             publish=False,
         )
+
         with self.login_user_context(self.superuser):
             response = self.client.get(draft_file.canonical_url)
-        self.assertRedirects(response, draft_file.url)
+        self.assertRedirects(response, draft_file.file.url)
 
     def test_ajax_upload_clipboardadmin(self):
         file = self.create_file('test2.pdf')
@@ -619,12 +621,16 @@ class FilerViewTests(BaseFilerVersioningTestCase):
         self.assertEqual(file2.url, '/media/f1/f2/test.xls')
         self.assertEqual(file3.url, '/media/f1/f3/test.xls')
         self.assertEqual(file4.url, '/media/f1/f3/f4/test.xls')
-        self.assertIn('filer_public', draft_file.url)
-        self.assertIn('test2.xls', draft_file.url)
-        self.assertIn('filer_public', unpublished_file.url)
-        self.assertIn('test3.xls', unpublished_file.url)
-        self.assertIn('filer_public', archived_file.url)
-        self.assertIn('test4.xls', archived_file.url)
+
+        draft_url = get_url(CONTEXT, draft_file)
+        unpublished_url = get_url(CONTEXT, unpublished_file)
+        archived_url = get_url(CONTEXT, archived_file)
+        self.assertIn('filer_public', draft_url)
+        self.assertIn('test2.xls', draft_url)
+        self.assertIn('filer_public', unpublished_url)
+        self.assertIn('test3.xls', unpublished_url)
+        self.assertIn('filer_public', archived_url)
+        self.assertIn('test4.xls', archived_url)
 
         with self.login_user_context(self.superuser):
             self.client.post(
@@ -634,21 +640,25 @@ class FilerViewTests(BaseFilerVersioningTestCase):
         for f in files:
             with nonversioned_manager(File):
                 f.refresh_from_db()
+                f.grouper.file.refresh_from_db()
 
+        draft_url = get_url(CONTEXT, draft_file)
+        unpublished_url = get_url(CONTEXT, unpublished_file)
+        archived_url = get_url(CONTEXT, archived_file)
         self.assertEqual(file0.url, '/media/f00/test.xls')
         self.assertEqual(file1.url, '/media/f10/test.xls')
         self.assertEqual(file2.url, '/media/f10/f2/test.xls')
         self.assertEqual(file3.url, '/media/f10/f3/test.xls')
         self.assertEqual(file4.url, '/media/f10/f3/f4/test.xls')
-        self.assertIn('filer_public', draft_file.url)
-        self.assertIn('test2.xls', draft_file.url)
-        self.assertNotIn('f10', draft_file.url)
-        self.assertIn('filer_public', unpublished_file.url)
-        self.assertIn('test3.xls', unpublished_file.url)
-        self.assertNotIn('f10', unpublished_file.url)
-        self.assertIn('filer_public', archived_file.url)
-        self.assertIn('test4.xls', archived_file.url)
-        self.assertNotIn('f10', archived_file.url)
+        self.assertIn('filer_public', draft_url)
+        self.assertIn('test2.xls', draft_url)
+        self.assertNotIn('f10', draft_url)
+        self.assertIn('filer_public', unpublished_url)
+        self.assertIn('test3.xls', unpublished_url)
+        self.assertNotIn('f10', unpublished_url)
+        self.assertIn('filer_public', archived_url)
+        self.assertIn('test4.xls', archived_url)
+        self.assertNotIn('f10', archived_url)
 
         with self.login_user_context(self.superuser):
             self.client.post(
@@ -658,21 +668,25 @@ class FilerViewTests(BaseFilerVersioningTestCase):
         for f in files:
             with nonversioned_manager(File):
                 f.refresh_from_db()
+                f.grouper.file.refresh_from_db()
 
+        draft_url = get_url(CONTEXT, draft_file)
+        unpublished_url = get_url(CONTEXT, unpublished_file)
+        archived_url = get_url(CONTEXT, archived_file)
         self.assertEqual(file0.url, '/media/f00/test.xls')
         self.assertEqual(file1.url, '/media/f10/test.xls')
         self.assertEqual(file2.url, '/media/f10/f2/test.xls')
         self.assertEqual(file3.url, '/media/f10/f30%20test/test.xls')
         self.assertEqual(file4.url, '/media/f10/f30%20test/f4/test.xls')
-        self.assertIn('filer_public', draft_file.url)
-        self.assertIn('test2.xls', draft_file.url)
-        self.assertNotIn('f10', draft_file.url)
-        self.assertIn('filer_public', unpublished_file.url)
-        self.assertIn('test3.xls', unpublished_file.url)
-        self.assertNotIn('f10', unpublished_file.url)
-        self.assertIn('filer_public', archived_file.url)
-        self.assertIn('test4.xls', archived_file.url)
-        self.assertNotIn('f10', archived_file.url)
+        self.assertIn('filer_public', draft_url)
+        self.assertIn('test2.xls', draft_url)
+        self.assertNotIn('f10', draft_url)
+        self.assertIn('filer_public', unpublished_url)
+        self.assertIn('test3.xls', unpublished_url)
+        self.assertNotIn('f10', unpublished_url)
+        self.assertIn('filer_public', archived_url)
+        self.assertIn('test4.xls', archived_url)
+        self.assertNotIn('f10', archived_url)
 
     @skipUnless(
         'djangocms_moderation' in settings.INSTALLED_APPS,


### PR DESCRIPTION
To know whether an image should show the published or the unpublished image we need to use a template tag. So we've created the templatetag `get_url` that solves that. 

We've also monkeypatched url so that it always shows the published image, and if no published image exist, no image will be shown. 

Still need to fix tests. 