### PR TITLE
Fixes an issue where the FileGrouperWidget uses a deprecated rel.to to get the related model

### DIFF
--- a/djangocms_versioning_filer/fields/file.py
+++ b/djangocms_versioning_filer/fields/file.py
@@ -78,7 +78,7 @@ class AdminFileGrouperWidget(ForeignKeyRawIdWidget):
     def obj_for_value(self, value):
         try:
             key = self.rel.get_related_field().name
-            obj = self.rel.to._default_manager.get(**{key: value})
+            obj = self.rel.model._default_manager.get(**{key: value})
         except:  # noqa
             obj = None
         return obj


### PR DESCRIPTION
Replaces rel.to with rel.model for Django 2+