### PR TITLE
OPENCMS-997: Fix Image name attribute update issue in Image editor

### DIFF
--- a/djangocms_versioning_filer/monkeypatch/admin/folderadmin.py
+++ b/djangocms_versioning_filer/monkeypatch/admin/folderadmin.py
@@ -296,7 +296,7 @@ filer.admin.folderadmin.FolderAdmin.directory_listing = directory_listing  # noq
 def save_model(func):
     def inner(self, request, obj, form, change):
         func(self, request, obj, form, change)
-        if change and 'name' in form.changed_data:
+        if change and 'name' in form.changed_data and isinstance(obj, Folder):
             published_files = File.objects.filter(
                 folder__in=obj.get_descendants(include_self=True)
             )

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -2,9 +2,10 @@ coverage
 djangocms_helper
 flake8
 isort
-djangocms-picture
+django-filer<2.0.0
+djangocms-picture<3.0.0
 djangocms-audio
-djangocms-file
+djangocms-file<3.0.0
 djangocms-video
 django-classy-tags<2.0.0
 django-sekizai<2.0.0

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -743,7 +743,7 @@ class FilerViewTests(BaseFilerVersioningTestCase):
         """
         folder = Folder.objects.create(name='f0')
         draft_grouper = FileGrouper.objects.create()
-        new_file_name ='image1'
+        new_file_name = 'image1'
         image_file = self.create_image_obj(
             original_filename='image.jpg',
             publish=False,


### PR DESCRIPTION
Fix Image attribute name change issue in Image Editor.

when you open image inside a folder in Media Library from the media library and edit the name attribute and save the error ocurrs.
![Mediagallery_image_save_error](https://user-images.githubusercontent.com/18649264/94938642-06907480-04c9-11eb-889e-49f58b46c847.png)
