### PR TITLE
Release 1.0.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,9 @@ Changelog
 
 Unreleased
 ==========
+
+1.0.0 (2022-04-25)
+==================
 * feat: Added file list item actions burger menu
 * fix: Missing icon images in latest filer 2.x where the icons are now SVG
 * Python 3.8, 3.9 support added

--- a/djangocms_versioning_filer/__init__.py
+++ b/djangocms_versioning_filer/__init__.py
@@ -1,3 +1,3 @@
-__version__ = '0.0.14'
+__version__ = '1.0.0'
 
 default_app_config = 'djangocms_versioning_filer.apps.FilerVersioningAppConfig'


### PR DESCRIPTION
* feat: Added file list item actions burger menu
* fix: Missing icon images in latest filer 2.x where the icons are now SVG
* Python 3.8, 3.9 support added
* Django 3.0, 3.1 and 3.2 support added
* Python 3.5 and 3.6 support removed
* Django 1.11 support removed