### PR TITLE
backport-fix: File download burger menu link does not open in a new tab as per previous behavior

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,9 +4,7 @@ Changelog
 
 Unreleased
 ==========
-<<<<<<< pick/release-0.0.x-f84c372df1a9b2df090baf1c1edf29ab6f032ec1
 * backport-fix: File download burger menu link does not open in a new tab as per previous behavior
-=======
 
 0.2.0 (2022-04-28)
 ==================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 
 Unreleased
 ==========
+* port-fix: File download burger menu link does not open in a new tab as per previous behavior
 * feat: Added file constraint checks
 
 0.1.0 (2022-04-25)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,6 @@ Unreleased
 0.2.0 (2022-04-28)
 ==================
 * backport-feat: Customisable folder list admin file action buttons
->>>>>>> release/0.0.x
 * feat: Added file constraint checks
 
 0.1.0 (2022-04-25)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog
 
 Unreleased
 ==========
-* port-fix: File download burger menu link does not open in a new tab as per previous behavior
+* backport-fix: File download burger menu link does not open in a new tab as per previous behavior
 * feat: Added file constraint checks
 
 0.1.0 (2022-04-25)

--- a/djangocms_versioning_filer/static/djangocms_versioning_filer/js/admin_filer_list_actions.js
+++ b/djangocms_versioning_filer/static/djangocms_versioning_filer/js/admin_filer_list_actions.js
@@ -43,6 +43,12 @@
         li_anchor.setAttribute('class', 'cms-actions-dropdown-menu-item-anchor');
         li_anchor.setAttribute('href', $(item).attr('href'));
 
+        // Copy the target attribute if it is set
+        const itemTarget = $(item).attr('target');
+        if (itemTarget !== undefined) {
+          li_anchor.setAttribute('target', itemTarget);
+        }
+
         if ($(item).hasClass('cms-form-get-method')) {
           li_anchor.classList.add('cms-form-get-method'); // Ensure the fake-form selector is propagated to the new anchor
         }


### PR DESCRIPTION
Backort the fix taken from the django 3.x workstream: https://github.com/divio/djangocms-versioning-filer/commit/f84c372df1a9b2df090baf1c1edf29ab6f032ec1