### PR TITLE
Feature/sortable headers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,8 @@ Changelog
 
 Unreleased
 ==========
-• feat: Replace CircleCi with GitHub Actions for linting and tests
+* feat: Enable sorting by headers on the monkey patched directory_listing admin view
+* feat: Replace CircleCi with GitHub Actions for linting and tests
 * fix: File download burger menu link does not open in a new tab as per previous behavior
 * feat: Customisable folder list admin file action buttons
 

--- a/djangocms_versioning_filer/admin.py
+++ b/djangocms_versioning_filer/admin.py
@@ -1,12 +1,7 @@
 import copy
-from collections import OrderedDict
-
-from django.utils.http import urlencode
 
 from djangocms_versioning.admin import VersioningAdminMixin
 from djangocms_versioning.models import Version
-from filer.admin import FolderAdmin
-from filer.models import Folder
 
 
 class VersioningFilerAdminMixin(VersioningAdminMixin):
@@ -21,68 +16,3 @@ class VersioningFilerAdminMixin(VersioningAdminMixin):
                     f for f in fieldset[1]['fields'] if f != 'changed_filename'
                 )
         return fieldsets
-
-
-class SortableHeadersChangeList:
-
-    ORDER_VAR = "o"
-    model = Folder
-    model_admin = FolderAdmin
-    # action_checkbox needs to be included so that the column numbers are correctly aligned when the result_headers
-    # template tag runs through the list_display
-    list_display = ["action_checkbox", "name", "owner", "modified_at"]
-    sortable_by = ["name", "owner", "modified_at"]
-
-    def __init__(self, request):
-        self.params = dict(request.GET.items())
-
-    def get_ordering_field_columns(self):
-        """
-        Build ordering dict made up of column number, and ordering type e.g.:
-        {
-            1: "asc",
-            2: "desc",
-            3: "asc",
-        }
-        This is then used by the result_headers templatetag to indicate which columns are being used for sorting.
-        It is used purely for display purposes and to build the links used by the sorting headers.
-        """
-        ordered_by = self.params.get(self.ORDER_VAR)
-        ordering = OrderedDict()
-        if not ordered_by:
-            # default to indicate ordering by name, as this is how the files are ordered by default in the
-            # directory_listing view
-            index = self.list_display.index("name")
-            ordering[index] = "asc"
-            return ordering
-
-        for order in ordered_by.split("."):
-            _, desc, col_num = order.rpartition('-')
-            try:
-                col_num = int(col_num)
-            except ValueError:
-                continue  # skip it
-            ordering[col_num] = 'desc' if desc == '-' else 'asc'
-
-        return ordering
-
-    def get_query_string(self, new_params=None, remove=None):
-        """
-        Method copied unchanged from django.contrib.admin.views.main.ChangeList
-        """
-        if new_params is None:
-            new_params = {}
-        if remove is None:
-            remove = []
-        p = self.params.copy()
-        for r in remove:
-            for k in list(p):
-                if k.startswith(r):
-                    del p[k]
-        for k, v in new_params.items():
-            if v is None:
-                if k in p:
-                    del p[k]
-            else:
-                p[k] = v
-        return '?%s' % urlencode(sorted(p.items()))

--- a/djangocms_versioning_filer/admin.py
+++ b/djangocms_versioning_filer/admin.py
@@ -1,7 +1,7 @@
 import copy
 from collections import OrderedDict
 
-from django.contrib.admin.views.main import ChangeList
+from django.utils.http import urlencode
 
 from djangocms_versioning.admin import VersioningAdminMixin
 from djangocms_versioning.models import Version
@@ -23,13 +23,66 @@ class VersioningFilerAdminMixin(VersioningAdminMixin):
         return fieldsets
 
 
-class SortableHeadersChangeList(ChangeList):
+class SortableHeadersChangeList:
 
+    ORDER_VAR = "o"
     model = Folder
     model_admin = FolderAdmin
+    # action_checkbox needs to be included so that the column numbers are correctly aligned when the result_headers
+    # template tag runs through the list_display
     list_display = ["action_checkbox", "name", "owner", "modified_at"]
     sortable_by = ["name", "owner", "modified_at"]
 
-    def __init__(self, request):  # noqa
+    def __init__(self, request):
         self.params = dict(request.GET.items())
-        self.lookup_opts = self.model._meta
+
+    def get_ordering_field_columns(self):
+        """
+        Build ordering dict made up of column number, and ordering type e.g.:
+        {
+            1: "asc",
+            2: "desc",
+            3: "asc",
+        }
+        This is then used by the result_headers templatetag to indicate which columns are being used for sorting.
+        It is used purely for display purposes and to build the links used by the sorting headers.
+        """
+        ordered_by = self.params.get(self.ORDER_VAR)
+        ordering = OrderedDict()
+        if not ordered_by:
+            # default to indicate ordering by name, as this is how the files are ordered by default in the
+            # directory_listing view
+            index = self.list_display.index("name")
+            ordering[index] = "asc"
+            return ordering
+
+        for order in ordered_by.split("."):
+            _, desc, col_num = order.rpartition('-')
+            try:
+                col_num = int(col_num)
+            except ValueError:
+                continue  # skip it
+            ordering[col_num] = 'desc' if desc == '-' else 'asc'
+
+        return ordering
+
+    def get_query_string(self, new_params=None, remove=None):
+        """
+        Method copied unchanged from django.contrib.admin.views.main.ChangeList
+        """
+        if new_params is None:
+            new_params = {}
+        if remove is None:
+            remove = []
+        p = self.params.copy()
+        for r in remove:
+            for k in list(p):
+                if k.startswith(r):
+                    del p[k]
+        for k, v in new_params.items():
+            if v is None:
+                if k in p:
+                    del p[k]
+            else:
+                p[k] = v
+        return '?%s' % urlencode(sorted(p.items()))

--- a/djangocms_versioning_filer/admin.py
+++ b/djangocms_versioning_filer/admin.py
@@ -1,7 +1,11 @@
 import copy
+from collections import OrderedDict
+
+from django.contrib.admin.views.main import ChangeList
 
 from djangocms_versioning.admin import VersioningAdminMixin
 from djangocms_versioning.models import Version
+from filer.models import Folder
 
 
 class VersioningFilerAdminMixin(VersioningAdminMixin):
@@ -16,3 +20,15 @@ class VersioningFilerAdminMixin(VersioningAdminMixin):
                     f for f in fieldset[1]['fields'] if f != 'changed_filename'
                 )
         return fieldsets
+
+
+class SortableHeadersChangeList(ChangeList):
+
+    model = Folder
+    sortable_by = ["name", "owner", "modified_at"]
+    list_display = ["action_checkbox", "name", "owner", "modified_at"]
+
+    def __init__(self, request, model_admin):
+        self.params = dict(request.GET.items())
+        self.model_admin = model_admin
+        self.lookup_opts = self.model._meta

--- a/djangocms_versioning_filer/admin.py
+++ b/djangocms_versioning_filer/admin.py
@@ -30,6 +30,6 @@ class SortableHeadersChangeList(ChangeList):
     list_display = ["action_checkbox", "name", "owner", "modified_at"]
     sortable_by = ["name", "owner", "modified_at"]
 
-    def __init__(self, request):
+    def __init__(self, request):  # noqa
         self.params = dict(request.GET.items())
         self.lookup_opts = self.model._meta

--- a/djangocms_versioning_filer/admin.py
+++ b/djangocms_versioning_filer/admin.py
@@ -5,6 +5,7 @@ from django.contrib.admin.views.main import ChangeList
 
 from djangocms_versioning.admin import VersioningAdminMixin
 from djangocms_versioning.models import Version
+from filer.admin import FolderAdmin
 from filer.models import Folder
 
 
@@ -25,10 +26,10 @@ class VersioningFilerAdminMixin(VersioningAdminMixin):
 class SortableHeadersChangeList(ChangeList):
 
     model = Folder
-    sortable_by = ["name", "owner", "modified_at"]
+    model_admin = FolderAdmin
     list_display = ["action_checkbox", "name", "owner", "modified_at"]
+    sortable_by = ["name", "owner", "modified_at"]
 
-    def __init__(self, request, model_admin):
+    def __init__(self, request):
         self.params = dict(request.GET.items())
-        self.model_admin = model_admin
         self.lookup_opts = self.model._meta

--- a/djangocms_versioning_filer/monkeypatch/admin/folderadmin.py
+++ b/djangocms_versioning_filer/monkeypatch/admin/folderadmin.py
@@ -384,5 +384,3 @@ def get_actions(func):
 filer.admin.folderadmin.FolderAdmin.get_actions = get_actions(  # noqa: E305
     filer.admin.folderadmin.FolderAdmin.get_actions
 )
-# filer.admin.folderadmin.FolderAdmin.list_display = ["name", "owner", "modified_at"]
-# filer.admin.folderadmin.FolderAdmin.sortable_by = ["name", "owner", "modified_at"]

--- a/djangocms_versioning_filer/monkeypatch/admin/folderadmin.py
+++ b/djangocms_versioning_filer/monkeypatch/admin/folderadmin.py
@@ -1,5 +1,4 @@
 from django.contrib.admin import helpers
-from django.contrib.admin.templatetags.admin_list import result_headers
 from django.core.exceptions import PermissionDenied
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 from django.db import models
@@ -28,7 +27,7 @@ from filer.models import (
 )
 from filer.utils.loader import load_model
 
-from ...admin import SortableHeadersChangeList
+from ..helpers import SortableHeaderHelper
 from ...helpers import (
     create_file_version,
     get_published_file_path,
@@ -261,9 +260,7 @@ def directory_listing(self, request, folder_id=None, viewtype=None):
         paginated_items = paginator.page(paginator.num_pages)
 
     # build sortable headers
-    cl = SortableHeadersChangeList(request)
-    sortable_headers = [header for header in result_headers(cl) if header["sortable"]]
-    num_sorted_fields = len([header for header in sortable_headers if header["sorted"]])
+    sortable_header_helper = SortableHeaderHelper(request=request)
 
     context = self.admin_site.each_context(request)
     context.update({
@@ -300,8 +297,8 @@ def directory_listing(self, request, folder_id=None, viewtype=None):
         'can_make_folder': request.user.is_superuser or (
             folder.is_root and filer.settings.FILER_ALLOW_REGULAR_USERS_TO_ADD_ROOT_FOLDERS
         ) or permissions.get("has_add_children_permission"),
-        'sortable_headers': sortable_headers,
-        'num_sorted_fields': num_sorted_fields,
+        'sortable_headers': sortable_header_helper.sortable_headers,
+        'num_sorted_fields': sortable_header_helper.num_headers_sorted,
         'order_by': order_by_str,
     })
     return render(request, self.directory_listing_template, context)

--- a/djangocms_versioning_filer/monkeypatch/admin/folderadmin.py
+++ b/djangocms_versioning_filer/monkeypatch/admin/folderadmin.py
@@ -79,11 +79,6 @@ def order_qs(queryset, order_by):
     return queryset.order_by(*order_by).distinct()
 
 
-def get_sortable_headers(request):
-    cl = SortableHeadersChangeList(request)
-    return [header for header in result_headers(cl) if header["sortable"]]
-
-
 def directory_listing(self, request, folder_id=None, viewtype=None):
     clipboard = tools.get_user_clipboard(request.user)
     if viewtype == 'images_with_missing_data':
@@ -247,7 +242,8 @@ def directory_listing(self, request, folder_id=None, viewtype=None):
         paginated_items = paginator.page(paginator.num_pages)
 
     # build sortable headers
-    sortable_headers = get_sortable_headers(request)
+    cl = SortableHeadersChangeList(request)
+    sortable_headers = [header for header in result_headers(cl) if header["sortable"]]
     num_sorted_fields = len([header for header in sortable_headers if header["sorted"]])
 
     context = self.admin_site.each_context(request)

--- a/djangocms_versioning_filer/monkeypatch/admin/folderadmin.py
+++ b/djangocms_versioning_filer/monkeypatch/admin/folderadmin.py
@@ -27,7 +27,6 @@ from filer.models import (
 )
 from filer.utils.loader import load_model
 
-from ..helpers import SortableHeaderHelper
 from ...helpers import (
     create_file_version,
     get_published_file_path,
@@ -35,6 +34,7 @@ from ...helpers import (
     move_file,
 )
 from ...models import FileGrouper, get_files_distinct_grouper_queryset
+from ..helpers import SortableHeaderHelper
 
 
 try:

--- a/djangocms_versioning_filer/monkeypatch/admin/folderadmin.py
+++ b/djangocms_versioning_filer/monkeypatch/admin/folderadmin.py
@@ -1,5 +1,3 @@
-import re
-
 from django.contrib.admin import helpers
 from django.contrib.admin.templatetags.admin_list import result_headers
 from django.core.exceptions import PermissionDenied

--- a/djangocms_versioning_filer/monkeypatch/admin/folderadmin.py
+++ b/djangocms_versioning_filer/monkeypatch/admin/folderadmin.py
@@ -82,6 +82,11 @@ def validate_order_by(order_by):
     return [key for key in order_by.split('.') if key in FOLDER_MAPPING or key in FILE_MAPPING]
 
 
+def get_sortable_headers(request):
+    cl = SortableHeadersChangeList(request)
+    return [header for header in result_headers(cl) if header["sortable"]]
+
+
 def directory_listing(self, request, folder_id=None, viewtype=None):
     clipboard = tools.get_user_clipboard(request.user)
     if viewtype == 'images_with_missing_data':
@@ -250,16 +255,8 @@ def directory_listing(self, request, folder_id=None, viewtype=None):
         paginated_items = paginator.page(paginator.num_pages)
 
     # build sortable headers
-    # TODO consider extracting
-    self.list_display = ["name", "owner", "modified_at"]
-    self.sortable_by = ["name", "owner", "modified_at"]
-    cl = SortableHeadersChangeList(request, self)
-    sortable_headers = [header for header in result_headers(cl) if header["sortable"]]
-
-    num_sorted_fields = 0
-    for h in sortable_headers:
-        if h['sortable'] and h['sorted']:
-            num_sorted_fields += 1
+    sortable_headers = get_sortable_headers(request)
+    num_sorted_fields = len([header for header in sortable_headers if header["sorted"]])
 
     context = self.admin_site.each_context(request)
     context.update({

--- a/djangocms_versioning_filer/monkeypatch/admin/folderadmin.py
+++ b/djangocms_versioning_filer/monkeypatch/admin/folderadmin.py
@@ -30,6 +30,7 @@ from filer.models import (
 )
 from filer.utils.loader import load_model
 
+from ...admin import SortableHeadersChangeList
 from ...helpers import (
     create_file_version,
     get_published_file_path,
@@ -252,7 +253,7 @@ def directory_listing(self, request, folder_id=None, viewtype=None):
     # TODO consider extracting
     self.list_display = ["name", "owner", "modified_at"]
     self.sortable_by = ["name", "owner", "modified_at"]
-    cl = self.get_changelist_instance(request)
+    cl = SortableHeadersChangeList(request, self)
     sortable_headers = [header for header in result_headers(cl) if header["sortable"]]
 
     num_sorted_fields = 0
@@ -297,6 +298,7 @@ def directory_listing(self, request, folder_id=None, viewtype=None):
         ) or permissions.get("has_add_children_permission"),
         'sortable_headers': sortable_headers,
         'num_sorted_fields': num_sorted_fields,
+        'order_by': ".".join(order_by)
     })
     return render(request, self.directory_listing_template, context)
 

--- a/djangocms_versioning_filer/monkeypatch/admin/folderadmin.py
+++ b/djangocms_versioning_filer/monkeypatch/admin/folderadmin.py
@@ -69,7 +69,7 @@ def ordering_mapping(model):
 
 def validate_order_by(order_by_str, mapping):
     """
-    Splits a string of ordering heys, and returns a list of keys of those that are in the given mapping dictionary
+    Splits a string of ordering keys, and returns a list of keys of those that are in the given mapping dictionary
     """
     return [key for key in order_by_str.split(".") if key in mapping]
 

--- a/djangocms_versioning_filer/monkeypatch/helpers.py
+++ b/djangocms_versioning_filer/monkeypatch/helpers.py
@@ -1,0 +1,76 @@
+from collections import OrderedDict
+
+from django.contrib.admin.templatetags.admin_list import result_headers, ORDER_VAR
+from django.utils.http import urlencode
+from filer.admin import FolderAdmin
+from filer.models import Folder
+
+
+class SortableHeaderHelper:
+
+    # attrs required for by result_headers
+    model = Folder
+    model_admin = FolderAdmin
+    # action_checkbox needs to be included so that the column numbers are correctly aligned
+    list_display = ["action_checkbox", "name", "owner", "modified_at"]
+    sortable_by = ["name", "owner", "modified_at"]
+
+    def __init__(self, request):
+        self.params = dict(request.GET.items())
+        self.sortable_headers = [header for header in result_headers(self) if header["sortable"]]
+
+    @property
+    def num_headers_sorted(self):
+        """
+        Count the number of headers currently sorted by
+        """
+        return len([header for header in self.sortable_headers if header["sorted"]])
+
+    def get_ordering_field_columns(self):
+        """
+        Build ordering dict made up of column number, and ordering type e.g.:
+        {
+            1: "asc",
+            2: "desc",
+            3: "asc",
+        }
+        This is then used by the result_headers templatetag to indicate which columns are being used for sorting.
+        It is used purely for display purposes and to build the links used by the sorting headers.
+        """
+        ordered_by = self.params.get(ORDER_VAR)
+        ordering = OrderedDict()
+        if not ordered_by:
+            # default to indicate ordered by name column, as this is the default ordering in the directory_listing view
+            ordering[self.list_display.index("name")] = "asc"
+            return ordering
+
+        for order in ordered_by.split("."):
+            _, desc, col_num = order.rpartition('-')
+            try:
+                col_num = int(col_num)
+            except ValueError:
+                continue  # skip it
+            ordering[col_num] = 'desc' if desc == '-' else 'asc'
+
+        return ordering
+
+    def get_query_string(self, new_params=None, remove=None):
+        """
+        Method copied unchanged from django.contrib.admin.views.main.ChangeList
+        """
+        if new_params is None:
+            new_params = {}
+        if remove is None:
+            remove = []
+        p = self.params.copy()
+        for r in remove:
+            for k in list(p):
+                if k.startswith(r):
+                    del p[k]
+        for k, v in new_params.items():
+            if v is None:
+                if k in p:
+                    del p[k]
+            else:
+                p[k] = v
+        return '?%s' % urlencode(sorted(p.items()))

--- a/djangocms_versioning_filer/monkeypatch/helpers.py
+++ b/djangocms_versioning_filer/monkeypatch/helpers.py
@@ -1,7 +1,11 @@
 from collections import OrderedDict
 
-from django.contrib.admin.templatetags.admin_list import result_headers, ORDER_VAR
+from django.contrib.admin.templatetags.admin_list import (
+    ORDER_VAR,
+    result_headers,
+)
 from django.utils.http import urlencode
+
 from filer.admin import FolderAdmin
 from filer.models import Folder
 

--- a/djangocms_versioning_filer/monkeypatch/helpers.py
+++ b/djangocms_versioning_filer/monkeypatch/helpers.py
@@ -7,6 +7,11 @@ from filer.models import Folder
 
 
 class SortableHeaderHelper:
+    """
+    Object used to build the sortable headers in the monkey patched directory_listing view. Implements the minimum
+    required attributes and methods to allow us to use the django provided result_headers templatetag function, rather
+    than using a full ChangeList class which this method expects.
+    """
 
     # attrs required for by result_headers
     model = Folder

--- a/djangocms_versioning_filer/templates/admin/filer/folder/_sortable_headers.html
+++ b/djangocms_versioning_filer/templates/admin/filer/folder/_sortable_headers.html
@@ -1,0 +1,17 @@
+{% load i18n %}
+
+{% for header in sortable_headers %}
+    <th scope="col"{{ header.class_attrib }}>
+       {% if header.sortable %}
+         {% if header.sort_priority > 0 %}
+           <div class="sortoptions">
+             <a class="sortremove" href="{{ header.url_remove }}" title="{% trans "Remove from sorting" %}"></a>
+             {% if num_sorted_fields > 1 %}<span class="sortpriority" title="{% blocktrans with priority_number=header.sort_priority %}Sorting priority: {{ priority_number }}{% endblocktrans %}">{{ header.sort_priority }}</span>{% endif %}
+             <a href="{{ header.url_toggle }}" class="toggle {% if header.ascending %}ascending{% else %}descending{% endif %}" title="{% trans "Toggle sorting" %}"></a>
+           </div>
+         {% endif %}
+       {% endif %}
+       <div class="text">{% if header.sortable %}<a href="{{ header.url_primary }}">{{ header.text|capfirst }}</a>{% else %}<span>{{ header.text|capfirst }}</span>{% endif %}</div>
+       <div class="clear"></div>
+    </th>
+{% endfor %}

--- a/djangocms_versioning_filer/templates/admin/filer/folder/directory_table.html
+++ b/djangocms_versioning_filer/templates/admin/filer/folder/directory_table.html
@@ -10,9 +10,7 @@
                     {% endif %}
                 </th>
                 <th class="column-icon">&nbsp;</th>
-                <th class="column-name">{% trans "Name" %}</th>
-                <th class="column-owner">{% trans "Owner" %}</th>
-                <th class="column-modified_date">{% trans "Modified date" %}</th>
+                {% include "admin/filer/folder/_sortable_headers.html" with sortable_headers=sortable_headers %}
                 <th class="column-size">{% trans "Size" %}</th>
                 <th class="column-action">{% trans "Action" %}</th>
             </tr>

--- a/djangocms_versioning_filer/templates/admin/filer/folder/directory_table.html
+++ b/djangocms_versioning_filer/templates/admin/filer/folder/directory_table.html
@@ -201,7 +201,7 @@
 
     <div class="nav-pages paginator">
         {% if paginated_items.has_previous %}
-            <a href="?page={{ paginated_items.previous_page_number }}{% if q %}&amp;q={{ q }}{% endif %}{% filer_admin_context_url_params '&' %}">
+            <a href="?page={{ paginated_items.previous_page_number }}{% if q %}&amp;q={{ q }}{% endif %}{% if order_by %}&o={{ order_by }}{% endif %}{% filer_admin_context_url_params '&' %}">
                 {% trans "previous" %}
             </a>
         {% endif %}
@@ -211,7 +211,7 @@
         </span>
 
         {% if paginated_items.has_next %}
-            <a href="?page={{ paginated_items.next_page_number }}{% if q %}&amp;q={{ q }}{% endif %}{% filer_admin_context_url_params '&' %}">
+            <a href="?page={{ paginated_items.next_page_number }}{% if q %}&amp;q={{ q }}{% endif %}{% if order_by %}&o={{ order_by }}{% endif %}{% filer_admin_context_url_params '&' %}">
                 {% trans "next" %}
             </a>
         {% endif %}

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,137 @@
+from cms.test_utils.testcases import CMSTestCase
+
+from filer.admin import FolderAdmin
+from filer.models import Folder
+
+from djangocms_versioning_filer.monkeypatch.helpers import SortableHeaderHelper
+
+
+class TestSortableHeadersHelper(CMSTestCase):
+
+    def test_init(self):
+        """
+        The SortableHeaderHelper should initialise with the correct attributes to build the sortable headers
+        """
+        request = self.get_request("/?o=1.2.3")
+
+        helper = SortableHeaderHelper(request=request)
+
+        self.assertEqual(helper.model, Folder)
+        self.assertEqual(helper.model_admin, FolderAdmin)
+        self.assertEqual(helper.list_display, ["action_checkbox", "name", "owner", "modified_at"])
+        self.assertEqual(helper.sortable_by, ["name", "owner", "modified_at"])
+        self.assertEqual(helper.params, {"o": "1.2.3"})
+        self.assertEqual(helper.sortable_headers[0]["text"], "name")
+        self.assertEqual(helper.sortable_headers[1]["text"], "owner")
+        self.assertEqual(helper.sortable_headers[2]["text"], "modified at")
+
+    def test_num_headers_sorted(self):
+        """
+        Check the number of sorted headers matches the number of columns specified in the querystring
+        """
+        test_cases = [
+            # sorted by name column by default
+            {"order_by_param": "", "expected_sorted": 1},
+            {"order_by_param": "?o=1", "expected_sorted": 1},
+            {"order_by_param": "?o=1.2", "expected_sorted": 2},
+            {"order_by_param": "?o=1.2.3", "expected_sorted": 3},
+        ]
+
+        for case in test_cases:
+            order_by_param = case["order_by_param"]
+            num_expected_sorted = case["expected_sorted"]
+            request = self.get_request(f"/{order_by_param}")
+            helper = SortableHeaderHelper(request=request)
+            with self.subTest(msg=f"Expected sorted by {num_expected_sorted}"):
+                self.assertEqual(helper.num_headers_sorted, num_expected_sorted)
+
+    def test_num_headers_sorted_no_params(self):
+        """
+        Should be 1 as by sorting by name is the default when no ordering specified
+        """
+        request = self.get_request("/")
+
+        helper = SortableHeaderHelper(request=request)
+
+        self.assertEqual(helper.num_headers_sorted, 1)
+
+    def test_get_ordering_field_columns_no_ordering_param(self):
+        """
+        When no ordering is specified, it should default to the name column in ascending order
+        """
+        request = self.get_request("/")
+        helper = SortableHeaderHelper(request)
+
+        ordering = helper.get_ordering_field_columns()
+
+        self.assertEqual(dict(ordering), {1: "asc"})
+
+    def test_get_ordering_field_columns_with_ordering_param(self):
+        """
+        A dictionary of the row number and ordering type is returned to match the ordering querystring
+        """
+        test_cases = [
+            {
+                "qs": "1.2.3",
+                "expected": {
+                    1: "asc",
+                    2: "asc",
+                    3: "asc",
+                }
+            },
+            {
+                "qs": "1",
+                "expected": {
+                    1: "asc",
+                }
+            },
+            {
+                "qs": "2",
+                "expected": {
+                    2: "asc",
+                }
+            },
+            {
+                "qs": "3",
+                "expected": {
+                    3: "asc",
+                }
+            },
+
+        ]
+        for test_case in test_cases:
+            qs = test_case["qs"]
+            request = self.get_request(f"/?o={qs}")
+            helper = SortableHeaderHelper(request)
+            with self.subTest(msg=request):
+                ordering = helper.get_ordering_field_columns()
+
+                self.assertEqual(dict(ordering), test_case["expected"])
+
+    def test_get_ordering_field_columns_descending(self):
+        """
+        When column number is preceded by - it is ordered in descending order
+        """
+        request = self.get_request("/?o=-1.-2.-3")
+        helper = SortableHeaderHelper(request)
+
+        ordering = helper.get_ordering_field_columns()
+        expected = {
+            1: "desc",
+            2: "desc",
+            3: "desc",
+        }
+        self.assertEqual(dict(ordering), expected)
+
+    def test_get_ordering_field_invalid_value(self):
+        """
+        Invalid ordering values are ignored
+        """
+        request = self.get_request("/?o=foo.2.bar")
+        helper = SortableHeaderHelper(request)
+
+        ordering = helper.get_ordering_field_columns()
+        expected = {
+            2: "asc",
+        }
+        self.assertEqual(dict(ordering), expected)

--- a/tests/test_monkeypatch.py
+++ b/tests/test_monkeypatch.py
@@ -1,0 +1,138 @@
+from unittest.mock import MagicMock
+
+from cms.test_utils.testcases import CMSTestCase
+from django.db.models import QuerySet
+from django.db.models.functions import Lower
+from filer.models import Folder, File
+
+from djangocms_versioning_filer.monkeypatch.admin.folderadmin import order_qs, ordering_mapping, validate_order_by
+
+
+class TestFolderAdminOrderingMapping(CMSTestCase):
+
+    def test_for_folder(self):
+        result = ordering_mapping(Folder)
+        expected = {
+            "1": [Lower("name")],
+            "2": ["owner__username"],
+            "3": ["modified_at"],
+            "-1": [Lower("name").desc()],
+            "-2": ["-owner__username"],
+            "-3": ["-modified_at"],
+        }
+
+        self.assertEqual(result, expected)
+
+    def test_for_file(self):
+        result = ordering_mapping(File)
+        expected = {
+            "1": [Lower("name"), Lower("original_filename")],
+            "2": ["owner__username"],
+            "3": ["modified_at"],
+            "-1": [Lower("name").desc(), Lower("original_filename").desc()],
+            "-2": ["-owner__username"],
+            "-3": ["-modified_at"],
+        }
+
+        self.assertEqual(result, expected)
+
+
+class TestFolderAdminValidateOrderBy(CMSTestCase):
+
+    def setUp(self):
+        self.mapping = {
+            "1": "foo",
+            "2": "bar",
+            "3": "foobar",
+        }
+
+    def test_when_not_in_mapping(self):
+        order_by = "9.8.7.6.foo"
+
+        result = validate_order_by(order_by_str=order_by, mapping=self.mapping)
+
+        self.assertEqual(result, [])
+
+    def test_when_in_mapping(self):
+        order_by = "1.2.3"
+
+        result = validate_order_by(order_by_str=order_by, mapping=self.mapping)
+
+        self.assertEqual(result, ["1", "2", "3"])
+
+    def test_when_some_in_mapping(self):
+        order_by = "1.2.3.4.5.6"
+
+        result = validate_order_by(order_by_str=order_by, mapping=self.mapping)
+
+        self.assertEqual(result, ["1", "2", "3"])
+
+
+class TestFolderAdminOrderQs(CMSTestCase):
+
+    # def setUp(self):
+    #     self.mapping = {
+    #         "1": "foo",
+    #         "2": "foo",
+    #         "3": "foo",
+    #     }
+
+    def test_when_valid_order_by_string(self):
+        queryset = MagicMock(spec=QuerySet)
+        queryset.model = File
+        order_by = "2"
+
+        order_qs(queryset, order_by)
+
+        queryset.order_by.assert_called_once_with("owner__username")
+
+    def test_when_invalid_order_by_string_file(self):
+        queryset = MagicMock(spec=QuerySet)
+        queryset.model = File
+        order_by = "4"
+
+        order_qs(queryset, order_by)
+
+        queryset.order_by.assert_called_once_with(Lower("name"), Lower("original_filename"))
+
+    def test_when_invalid_order_by_string_folder(self):
+        queryset = MagicMock(spec=QuerySet)
+        queryset.model = Folder
+        order_by = "4"
+
+        order_qs(queryset, order_by)
+
+        queryset.order_by.assert_called_once_with(Lower("name"))
+
+    def test_multiple_valid_ordering(self):
+        queryset = MagicMock(spec=QuerySet)
+        queryset.model = File
+        order_by = "1.2.3"
+
+        order_qs(queryset, order_by)
+
+        queryset.order_by.assert_called_once_with(
+            Lower("name"), Lower("original_filename"), "owner__username", "modified_at",
+        )
+
+    def test_order_descending(self):
+        queryset = MagicMock(spec=QuerySet)
+        queryset.model = File
+        order_by = "-1.-2.-3"
+
+        order_qs(queryset, order_by)
+
+        queryset.order_by.assert_called_once_with(
+            Lower("name").desc(), Lower("original_filename").desc(), "-owner__username", "-modified_at",
+        )
+
+    def test_order_rows_in_reverse(self):
+        queryset = MagicMock(spec=QuerySet)
+        queryset.model = File
+        order_by = "3.2.1."
+
+        order_qs(queryset, order_by)
+
+        queryset.order_by.assert_called_once_with(
+            "modified_at", "owner__username", Lower("name"), Lower("original_filename"),
+        )

--- a/tests/test_monkeypatch.py
+++ b/tests/test_monkeypatch.py
@@ -1,11 +1,17 @@
 from unittest.mock import MagicMock
 
-from cms.test_utils.testcases import CMSTestCase
 from django.db.models import QuerySet
 from django.db.models.functions import Lower
-from filer.models import Folder, File
 
-from djangocms_versioning_filer.monkeypatch.admin.folderadmin import order_qs, ordering_mapping, validate_order_by
+from cms.test_utils.testcases import CMSTestCase
+
+from filer.models import File, Folder
+
+from djangocms_versioning_filer.monkeypatch.admin.folderadmin import (
+    order_qs,
+    ordering_mapping,
+    validate_order_by,
+)
 
 
 class TestFolderAdminOrderingMapping(CMSTestCase):


### PR DESCRIPTION
Adds sorting by the header columns on the monkey patched directory_listing view. Django already handles this on the admin changelist view, using the `sortable_by` column. However as the `directory_listing` is a custom view it was not possible to use this out of the box. Rather than reimplement the full feature, I have added a helper class that implements the minimal attributes and methods required for the the [result_headers](https://github.com/django/django/blob/main/django/contrib/admin/templatetags/admin_list.py#L84) template tag function to be used to build the headers, which can then be used in the monkey patched `directory_listing` view.

