### PR TITLE
fix: Edit admin action missing closing quotation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 
 Unreleased
 ==========
+* fix: Add missing closing quotation in template
 
 1.1.0 (2022-10-14)
 ==========

--- a/djangocms_versioning_filer/templates/djangocms_versioning_filer/admin/action_buttons/edit.html
+++ b/djangocms_versioning_filer/templates/djangocms_versioning_filer/admin/action_buttons/edit.html
@@ -23,6 +23,6 @@
 {% if not disabled %}
     href="{% get_versioning_filer_edit_url file %}"
 {% endif %}
-/>
+>
     <img src="{% static 'djangocms_versioning/svg/edit.svg' %}">
 {% endspaceless %}

--- a/djangocms_versioning_filer/templates/djangocms_versioning_filer/admin/action_buttons/edit.html
+++ b/djangocms_versioning_filer/templates/djangocms_versioning_filer/admin/action_buttons/edit.html
@@ -19,9 +19,10 @@
     js-versioning-action-btn
     js-versioning-action
     {% if keepsideframe|default_if_none:True %} js-versioning-keep-sideframe {% else %}js-versioning-close-sideframe {% endif %}
+    "
 {% if not disabled %}
     href="{% get_versioning_filer_edit_url file %}"
 {% endif %}
->
+/>
     <img src="{% static 'djangocms_versioning/svg/edit.svg' %}">
 {% endspaceless %}


### PR DESCRIPTION
Missing edit button closing quotation, which was causing formatting error when rendered.