### PR TITLE
feat: django-cms 4.1 Compatibility POC

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,11 +16,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ 3.8, 3.9, '3.10' ]
+        python-version: [ 3.8, 3.9, '3.10' '3.11', '3.12']
         requirements-file: [
             dj32_cms40.txt,
             dj42_cms40.txt,
+            dj42_cms41.txt,
         ]
+        exclude:
+          # CMS 4.0 does not support python 3.11+
+          - requirements-file: "dj32_cms40.txt"
+            python-version: ["3.11", "3.12"]
+          - requirements-file: "dj42_cms40.txt"
+            python-version: ["3.11", "3.12"]
+          # 3.8 is not required by django-cms 4.1+
+          - requirements-file: "dj42_cms41.txt"
+            python-version: ["3.8"]
 
     steps:
       - uses: actions/checkout@v3

--- a/test_settings.py
+++ b/test_settings.py
@@ -91,6 +91,7 @@ HELPER_SETTINGS = {
     'FILE_UPLOAD_TEMP_DIR': mkdtemp(),
     'FILER_CANONICAL_URL': 'test-path/',
     'DEFAULT_AUTO_FIELD': 'django.db.models.AutoField',
+    'CMS_CONFIRM_VERSION4': True,
 }
 
 

--- a/tests/requirements/dj32_cms40.txt
+++ b/tests/requirements/dj32_cms40.txt
@@ -1,3 +1,9 @@
 -r ./requirements_base.txt
 
 Django>=3.2,<4.0
+django-filer==2.2.3
+
+# Unreleased django-cms 4.0 compatible packages
+https://github.com/django-cms/django-cms/tarball/release/4.0.1.x#egg=django-cms
+https://github.com/django-cms/djangocms-versioning/tarball/support/django-cms-4.0.x#egg=djangocms-versioning
+https://github.com/django-cms/djangocms-moderation/tarball/master#egg=djangocms-moderation

--- a/tests/requirements/dj42_cms40.txt
+++ b/tests/requirements/dj42_cms40.txt
@@ -1,3 +1,9 @@
 -r ./requirements_base.txt
 
 Django>=4.2,<5.0
+django-filer==2.2.3
+
+# Unreleased django-cms 4.0 compatible packages
+https://github.com/django-cms/django-cms/tarball/release/4.0.1.x#egg=django-cms
+https://github.com/django-cms/djangocms-versioning/tarball/support/django-cms-4.0.x#egg=djangocms-versioning
+https://github.com/django-cms/djangocms-moderation/tarball/master#egg=djangocms-moderation

--- a/tests/requirements/dj42_cms41.txt
+++ b/tests/requirements/dj42_cms41.txt
@@ -1,0 +1,9 @@
+-r ./requirements_base.txt
+
+Django>=4.2,<5.0
+django-cms==4.1.2
+djangocms-versioning
+django-filer
+
+# Unreleased django-cms 4.0 compatible packages
+https://github.com/django-cms/djangocms-moderation/tarball/master#egg=djangocms-moderation

--- a/tests/requirements/requirements_base.txt
+++ b/tests/requirements/requirements_base.txt
@@ -1,7 +1,6 @@
 coverage
 django-app-helper
 django-classy-tags
-django-filer==2.2.3
 django-sekizai
 djangocms-audio
 djangocms-file
@@ -13,7 +12,3 @@ isort
 mock
 
 
-# Unreleased django-cms 4.0 compatible packages
-https://github.com/django-cms/django-cms/tarball/release/4.0.1.x#egg=django-cms
-https://github.com/django-cms/djangocms-versioning/tarball/support/django-cms-4.0.x#egg=djangocms-versioning
-https://github.com/django-cms/djangocms-moderation/tarball/master#egg=djangocms-moderation


### PR DESCRIPTION
What does this PR do?

- Adds django-cms 4.1 compatibility with django 4.2
- Adds python 3.11 and 3.12 compatibility with django 4.2

